### PR TITLE
Fixed the right click options not working on winOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.idea/
+.idea/*
 .gradle/
 out/
 Axeereraa.iml

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ jar {
     }
 }
 
-version '1.0.0-SNAPSHOT'
+version '1.0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/negassagisila/axeereraa/AxeereraaUI.java
+++ b/src/main/java/com/negassagisila/axeereraa/AxeereraaUI.java
@@ -80,8 +80,6 @@ public class AxeereraaUI extends JFrame {
     axRootScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
     axRootScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
     
-    axRootTextArea.addMouseListener(new RightClickOptions());
-    
     axRootScrollPane.getVerticalScrollBar().setPreferredSize(
             new Dimension(3, Integer.MAX_VALUE));
     
@@ -133,6 +131,8 @@ public class AxeereraaUI extends JFrame {
                     )
             )
     );
+    
+    axRootTextArea.setComponentPopupMenu(rightClickOptions);
   }
   
   /**
@@ -283,7 +283,7 @@ public class AxeereraaUI extends JFrame {
    * @param jEditorPane the editor pane that contains the markdown that will be displayed
    */
   private void showMarkdown(JEditorPane jEditorPane) {
-    jEditorPane.addMouseListener(new RightClickOptions());
+    jEditorPane.setComponentPopupMenu(rightClickOptions);
     axRootScrollPane.getViewport().remove(axRootTextArea);
     axRootScrollPane.getViewport().add(jEditorPane);
   }
@@ -477,29 +477,6 @@ public class AxeereraaUI extends JFrame {
       return this;
     }
     
-  }
-  
-  /**
-   * This class displays the right click options when the axRootTextArea is right clicked.
-   */
-  
-  private class RightClickOptions extends MouseAdapter {
-  
-    @Override
-    public void mousePressed(MouseEvent e) {
-      showRightClickOptions(e);
-    }
-  
-    @Override
-    public void mouseClicked(MouseEvent e) {
-      showRightClickOptions(e);
-    }
-  
-    private void showRightClickOptions(MouseEvent e) {
-      if (e.isPopupTrigger()) {
-        rightClickOptions.show(e.getComponent(), e.getX(), e.getY());
-      }
-    }
   }
   
   /**


### PR DESCRIPTION
I've modified the way the right click context menu appears so as to get
it work on windows OSes. Each component that has a context pop up menu
attached now calls it's own setComponentPopupMenu() method.